### PR TITLE
Updates dependency to Spree 3.4.5

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,7 +1,6 @@
 Spree::Payment.class_eval do
-  has_one :adjustment, :as => :source, :dependent => :destroy
 
-  # for Cash on Delivery
+
   def build_source
     return unless new_record?
 
@@ -11,6 +10,7 @@ Spree::Payment.class_eval do
       self.source.user_id = self.order.user_id if self.order
     end
 
+    # for Cash on Delivery
     if payment_method and payment_method.respond_to?(:post_create)
       payment_method.post_create(self)
     end

--- a/app/models/spree/payment_method/cash_on_delivery.rb
+++ b/app/models/spree/payment_method/cash_on_delivery.rb
@@ -1,6 +1,6 @@
 class Spree::PaymentMethod::CashOnDelivery < Spree::PaymentMethod
 
-    preference :fee, :float
+    preference :fee, :float, default: 0.0
 
     def payment_profiles_supported?
       true # we want to show the confirm step.

--- a/app/models/spree/payment_method/cash_on_delivery.rb
+++ b/app/models/spree/payment_method/cash_on_delivery.rb
@@ -68,4 +68,9 @@ class Spree::PaymentMethod::CashOnDelivery < Spree::PaymentMethod
     end
 
 
+    private
+
+    def fee_exists?(payment)
+      payment.order.adjustments.where("label = ?", label).exists?
+    end
 end

--- a/lib/generators/spree_cash_on_delivery/install/install_generator.rb
+++ b/lib/generators/spree_cash_on_delivery/install/install_generator.rb
@@ -1,4 +1,4 @@
-module SpreeCash0nDelivery
+module SpreeCashOnDelivery
   module Generators
     class InstallGenerator < Rails::Generators::Base
 

--- a/spree_cash_on_delivery.gemspec
+++ b/spree_cash_on_delivery.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_core', '~> 3.4.5'
 end

--- a/spree_cash_on_delivery.gemspec
+++ b/spree_cash_on_delivery.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_cash_on_delivery'
-  s.version     =  '3.0.0'
+  s.version     =  '3.1.0'
   s.summary     = 'Payment Method Cash On Delivery'
   s.description = 'Payment Method Cash On Delivery'
   s.author      = 'Pablo'


### PR DESCRIPTION
1. updates spree dependecny
2. self.preferred_fee was nil and there was error, that prevented checkout using COD method, fee_exists? method updated to check this
3. Solves typo in generator